### PR TITLE
refactor: add document class

### DIFF
--- a/cv_builder.py
+++ b/cv_builder.py
@@ -21,9 +21,9 @@ if __name__ == "__main__":
         "left": "25mm",
     }
     cv_document = Document(
+        pagestyle="empty",
         geometry_options=geometry_options,
     )
-    cv_document.preamble.append("\\pagestyle{empty}")
     cv_document.preamble.append("\\setlength\\parindent{0pt}")
     cv_document.preamble.append("\\usepackage{enumitem}")
 

--- a/cv_builder.py
+++ b/cv_builder.py
@@ -1,5 +1,7 @@
 import json
 
+from latex import Document
+
 CV_JSON_FILE = "cv.json"
 CV_TEX_FILE = "cv.tex"
 
@@ -10,61 +12,20 @@ def load_data(filepath: str = CV_JSON_FILE) -> dict:
     return cv_data
 
 
-def begin_document(document: list[str]) -> None:
-    document.append("\\begin{document}")
-
-
-def end_document(document: list[str]) -> None:
-    document.append("\\end{document}")
-
-
-def create_section(title: str) -> list[str]:
-    section: list[str] = []
-    section.append(f"\\section*{{{title}}}")
-    return section
-
-
-def create_subsection(title: str) -> list[str]:
-    section: list[str] = []
-    section.append(f"\\subsection*{{{title}}}")
-    return section
-
-
-def create_subsubsection(title: str) -> list[str]:
-    section: list[str] = []
-    section.append(f"\\subsubsection*{{{title}}}")
-    return section
-
-
-def generate_tex_file(
-    preamble: list[str],
-    document: list[str],
-    filepath: str = CV_TEX_FILE,
-) -> None:
-    with open(filepath, "w", encoding="utf-8") as f:
-        for line in preamble:
-            f.write(f"{line}\n")
-        for line in document:
-            f.write(f"{line}\n")
-
-
 if __name__ == "__main__":
     cv_data = load_data()
+    cv_document = Document()
 
-    preamble: list[str] = []
-    document: list[str] = []
+    cv_document.preamble.append("\\usepackage{geometry}")
+    cv_document.preamble.append("\\geometry{a4paper, left=25mm, top=20mm}")
+    cv_document.preamble.append("\\pagestyle{empty}")
+    cv_document.preamble.append("\\setlength\\parindent{0pt}")
+    cv_document.preamble.append("\\usepackage{enumitem}")
 
-    preamble.append("\\documentclass{article}")
-    preamble.append("\\usepackage{geometry}")
-    preamble.append("\\geometry{a4paper, left=25mm, top=20mm}")
-    preamble.append("\\pagestyle{empty}")
-    preamble.append("\\setlength\\parindent{0pt}")
-    preamble.append("\\usepackage{enumitem}")
-
-    begin_document(document)
+    cv_document.begin()
 
     profile_data = cv_data["profile"]
-    profile = create_section(profile_data["full_name"])
+    profile = cv_document.create_section(profile_data["full_name"])
     profile.append(
         " $|$ ".join(
             [
@@ -74,40 +35,40 @@ if __name__ == "__main__":
             ]
         )
     )
-    document.extend(profile)
+    cv_document.extend(profile)
 
-    summary = create_subsection("Summary")
+    summary = cv_document.create_subsection("Summary")
     summary.append(cv_data["summary"])
-    document.extend(summary)
+    cv_document.extend(summary)
 
-    experience = create_subsection("Experience")
+    experience = cv_document.create_subsection("Experience")
     for job_data in cv_data["experience"]:
-        job = create_subsubsection(job_data["job_title"])
+        job = cv_document.create_subsubsection(job_data["job_title"])
         job.append(f"{job_data['company']}, {job_data['location']}\\newline")
         job.append(f"{job_data['from_month']} - {job_data['to_month']}\\par")
         job.append("\\vspace*{1em}")
         job.append(job_data["description"])
         experience.extend(job)
-    document.extend(experience)
+    cv_document.extend(experience)
 
-    education = create_subsection("Education")
+    education = cv_document.create_subsection("Education")
     for edu_data in cv_data["education"]:
-        course = create_subsubsection(edu_data["course_title"])
+        course = cv_document.create_subsubsection(edu_data["course_title"])
         course.append(f"{edu_data['school']}, {edu_data['to_year']}")
         education.extend(course)
-    document.extend(education)
+    cv_document.extend(education)
 
-    skills = create_subsection("Skills")
+    skills = cv_document.create_subsection("Skills")
     skills.append("\\begin{itemize}[nosep]")
     for skill in cv_data["skills"]:
         skills.append(f"\\item {skill['description']} ({skill['competency']})")
     skills.append("\\end{itemize}")
-    document.extend(skills)
+    cv_document.extend(skills)
 
-    references = create_subsection("References")
+    references = cv_document.create_subsection("References")
     references.append("Available on request")
-    document.extend(references)
+    cv_document.extend(references)
 
-    end_document(document)
+    cv_document.end()
 
-    generate_tex_file(preamble, document)
+    cv_document.generate_tex(filepath=CV_TEX_FILE)

--- a/cv_builder.py
+++ b/cv_builder.py
@@ -14,10 +14,15 @@ def load_data(filepath: str = CV_JSON_FILE) -> dict:
 
 if __name__ == "__main__":
     cv_data = load_data()
-    cv_document = Document()
 
-    cv_document.preamble.append("\\usepackage{geometry}")
-    cv_document.preamble.append("\\geometry{a4paper, left=25mm, top=20mm}")
+    geometry_options = {
+        "paper": "a4paper",
+        "top": "20mm",
+        "left": "25mm",
+    }
+    cv_document = Document(
+        geometry_options=geometry_options,
+    )
     cv_document.preamble.append("\\pagestyle{empty}")
     cv_document.preamble.append("\\setlength\\parindent{0pt}")
     cv_document.preamble.append("\\usepackage{enumitem}")

--- a/cv_builder.py
+++ b/cv_builder.py
@@ -22,9 +22,9 @@ if __name__ == "__main__":
     }
     cv_document = Document(
         pagestyle="empty",
+        indent=False,
         geometry_options=geometry_options,
     )
-    cv_document.preamble.append("\\setlength\\parindent{0pt}")
     cv_document.preamble.append("\\usepackage{enumitem}")
 
     cv_document.begin()
@@ -51,7 +51,6 @@ if __name__ == "__main__":
         job = cv_document.create_subsubsection(job_data["job_title"])
         job.append(f"{job_data['company']}, {job_data['location']}\\newline")
         job.append(f"{job_data['from_month']} - {job_data['to_month']}\\par")
-        job.append("\\vspace*{1em}")
         job.append(job_data["description"])
         experience.extend(job)
     cv_document.extend(experience)

--- a/cv_builder.py
+++ b/cv_builder.py
@@ -12,20 +12,24 @@ def load_data(filepath: str = CV_JSON_FILE) -> dict:
     return cv_data
 
 
+class CVDocument(Document):
+    def __init__(self) -> None:
+        geometry_options = {
+            "paper": "a4paper",
+            "top": "20mm",
+            "left": "25mm",
+        }
+        super().__init__(
+            pagestyle="empty",
+            indent=False,
+            geometry_options=geometry_options,
+        )
+        self.preamble.usepackage("enumitem")
+
+
 if __name__ == "__main__":
     cv_data = load_data()
-
-    geometry_options = {
-        "paper": "a4paper",
-        "top": "20mm",
-        "left": "25mm",
-    }
-    cv_document = Document(
-        pagestyle="empty",
-        indent=False,
-        geometry_options=geometry_options,
-    )
-    cv_document.preamble.usepackage("enumitem")
+    cv_document = CVDocument()
 
     cv_document.begin()
 

--- a/cv_builder.py
+++ b/cv_builder.py
@@ -25,7 +25,7 @@ if __name__ == "__main__":
         indent=False,
         geometry_options=geometry_options,
     )
-    cv_document.preamble.append("\\usepackage{enumitem}")
+    cv_document.preamble.usepackage("enumitem")
 
     cv_document.begin()
 

--- a/latex.py
+++ b/latex.py
@@ -1,0 +1,46 @@
+class Document:
+    def __init__(
+        self,
+        documentclass: str = "article",
+    ) -> None:
+        self.preamble: list[str] = []
+        self._content: list[str] = []
+
+        self.preamble.append(f"\\documentclass{{{documentclass}}}")
+
+    def append(self, line: str) -> None:
+        self._content.append(line)
+
+    def extend(self, lines: list[str]) -> None:
+        self._content.extend(lines)
+
+    def begin(self) -> None:
+        self.append("\\begin{document}")
+
+    def end(self) -> None:
+        self.append("\\end{document}")
+
+    @staticmethod
+    def create_section(title: str) -> list[str]:
+        section: list[str] = []
+        section.append(f"\\section*{{{title}}}")
+        return section
+
+    @staticmethod
+    def create_subsection(title: str) -> list[str]:
+        section: list[str] = []
+        section.append(f"\\subsection*{{{title}}}")
+        return section
+
+    @staticmethod
+    def create_subsubsection(title: str) -> list[str]:
+        section: list[str] = []
+        section.append(f"\\subsubsection*{{{title}}}")
+        return section
+
+    def generate_tex(self, filepath: str) -> None:
+        with open(filepath, "w", encoding="utf-8") as f:
+            for line in self.preamble:
+                f.write(f"{line}\n")
+            for line in self._content:
+                f.write(f"{line}\n")

--- a/latex.py
+++ b/latex.py
@@ -2,6 +2,23 @@ def _options_dict_to_str(options_dict: dict) -> str:
     return ", ".join(f"{key}={value}" for key, value in options_dict.items())
 
 
+class Preamble:
+    def __init__(self) -> None:
+        self._content: list[str] = []
+
+    def append(self, line: str) -> None:
+        self._content.append(line)
+
+    def extend(self, lines: list[str]) -> None:
+        self._content.extend(lines)
+
+    def usepackage(self, name: str, options: dict | None = None) -> None:
+        self.append(f"\\usepackage{{{name}}}")
+        if options:
+            options_str = _options_dict_to_str(options)
+            self.append(f"\\{name}{{{options_str}}}")
+
+
 class Document:
     def __init__(
         self,
@@ -11,7 +28,7 @@ class Document:
         indent: bool = True,
         geometry_options: dict | None = None,
     ) -> None:
-        self.preamble: list[str] = []
+        self.preamble = Preamble()
         self._content: list[str] = []
 
         self.preamble.append(f"\\documentclass{{{documentclass}}}")
@@ -20,12 +37,10 @@ class Document:
             self.preamble.append(f"\\pagestyle{{{pagestyle}}}")
 
         if not indent:
-            self.preamble.append("\\usepackage{parskip}")
+            self.preamble.usepackage("parskip")
 
         if geometry_options:
-            self.preamble.append("\\usepackage{geometry}")
-            options_str = _options_dict_to_str(geometry_options)
-            self.preamble.append(f"\\geometry{{{options_str}}}")
+            self.preamble.usepackage("geometry", geometry_options)
 
     def append(self, line: str) -> None:
         self._content.append(line)
@@ -59,7 +74,7 @@ class Document:
 
     def generate_tex(self, filepath: str) -> None:
         with open(filepath, "w", encoding="utf-8") as f:
-            for line in self.preamble:
+            for line in self.preamble._content:
                 f.write(f"{line}\n")
             for line in self._content:
                 f.write(f"{line}\n")

--- a/latex.py
+++ b/latex.py
@@ -5,6 +5,7 @@ def _options_dict_to_str(options_dict: dict) -> str:
 class Document:
     def __init__(
         self,
+        *,
         documentclass: str = "article",
         geometry_options: dict | None = None,
     ) -> None:

--- a/latex.py
+++ b/latex.py
@@ -1,12 +1,22 @@
+def _options_dict_to_str(options_dict: dict) -> str:
+    return ", ".join(f"{key}={value}" for key, value in options_dict.items())
+
+
 class Document:
     def __init__(
         self,
         documentclass: str = "article",
+        geometry_options: dict | None = None,
     ) -> None:
         self.preamble: list[str] = []
         self._content: list[str] = []
 
         self.preamble.append(f"\\documentclass{{{documentclass}}}")
+
+        if geometry_options:
+            self.preamble.append("\\usepackage{geometry}")
+            options_str = _options_dict_to_str(geometry_options)
+            self.preamble.append(f"\\geometry{{{options_str}}}")
 
     def append(self, line: str) -> None:
         self._content.append(line)

--- a/latex.py
+++ b/latex.py
@@ -8,6 +8,7 @@ class Document:
         *,
         documentclass: str = "article",
         pagestyle: str | None = None,
+        indent: bool = True,
         geometry_options: dict | None = None,
     ) -> None:
         self.preamble: list[str] = []
@@ -17,6 +18,9 @@ class Document:
 
         if pagestyle:
             self.preamble.append(f"\\pagestyle{{{pagestyle}}}")
+
+        if not indent:
+            self.preamble.append("\\usepackage{parskip}")
 
         if geometry_options:
             self.preamble.append("\\usepackage{geometry}")

--- a/latex.py
+++ b/latex.py
@@ -7,12 +7,16 @@ class Document:
         self,
         *,
         documentclass: str = "article",
+        pagestyle: str | None = None,
         geometry_options: dict | None = None,
     ) -> None:
         self.preamble: list[str] = []
         self._content: list[str] = []
 
         self.preamble.append(f"\\documentclass{{{documentclass}}}")
+
+        if pagestyle:
+            self.preamble.append(f"\\pagestyle{{{pagestyle}}}")
 
         if geometry_options:
             self.preamble.append("\\usepackage{geometry}")

--- a/latex.py
+++ b/latex.py
@@ -18,6 +18,9 @@ class Preamble:
             options_str = _options_dict_to_str(options)
             self.append(f"\\{name}{{{options_str}}}")
 
+    def dumps(self) -> str:
+        return "\n".join(self._content)
+
 
 class Document:
     def __init__(
@@ -72,9 +75,11 @@ class Document:
         section.append(f"\\subsubsection*{{{title}}}")
         return section
 
+    def dumps(self) -> str:
+        preamble_dumps = self.preamble.dumps()
+        document_dumps = "\n".join(self._content)
+        return preamble_dumps + "\n\n" + document_dumps
+
     def generate_tex(self, filepath: str) -> None:
         with open(filepath, "w", encoding="utf-8") as f:
-            for line in self.preamble._content:
-                f.write(f"{line}\n")
-            for line in self._content:
-                f.write(f"{line}\n")
+            f.write(self.dumps())


### PR DESCRIPTION
Refactor to move all the Latex functions into a new `Document` class.

I _could_ just use the [PyLaTeX](https://github.com/JelteF/PyLaTeX) package instead, but attempting to roll my own solution was a good learning exercise (and more fun!)